### PR TITLE
update snowpack benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "style-loader": "^1.2.1",
     "file-loader": "^6.1.0",
     "@types/snowpack-env": "^2.3.0",
-    "@snowpack/app-scripts-react": "1.12.3",
-    "snowpack": "next"
+    "snowpack": "^2.15.0"
   }
 }

--- a/snowpack.config.json
+++ b/snowpack.config.json
@@ -1,4 +1,7 @@
 {
-  "extends": "@snowpack/app-scripts-react",
+  "mount": {
+    "src": "/_dist_",
+    "public": "/"
+  },
   "plugins": []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1359,10 +1359,10 @@
     "@babel/core" "^7.10.5"
     workerpool "^6.0.0"
 
-"@snowpack/plugin-build-script@^2.0.10":
-  version "2.0.10"
-  resolved "https://registry.yarnpkg.com/@snowpack/plugin-build-script/-/plugin-build-script-2.0.10.tgz#126f179a7bd8b603911ab345940e30e2882c6eb9"
-  integrity sha512-939mCxrvygPDH/osyGnR0KS+BnERW4Nnp+8NG9os8Ww1wI+V9nI/6a1qqoGhVbD8KX93bW8FrqMljLjXRb74eg==
+"@snowpack/plugin-build-script@^2.0.11":
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/@snowpack/plugin-build-script/-/plugin-build-script-2.0.11.tgz#50eb2b6127c8863cbbc6a3105042713e16818869"
+  integrity sha512-bLi7W0ry5OAhCEGuBL3PdLchWU+WaXa2aJYSJapt4FsfhUiNwi+ua1qiZ0syaXXfRq/2jx9eEkx4G7TGB8Kvsg==
   dependencies:
     execa "^4.0.3"
     npm-run-path "^4.0.1"
@@ -1384,10 +1384,10 @@
     "@babel/plugin-syntax-class-properties" "^7.10.0"
     react-refresh "^0.8.3"
 
-"@snowpack/plugin-run-script@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@snowpack/plugin-run-script/-/plugin-run-script-2.1.6.tgz#49399c1b8103e55a4fbac5601708ba25bf272372"
-  integrity sha512-62Rz1ln3igt5uzpLZceSZwGVOj7wmdPW/UoxCRqSvBQ5NLtLCWmzJYUj+trq4e+pUSQPJgQPC26iAraENpm0kA==
+"@snowpack/plugin-run-script@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@snowpack/plugin-run-script/-/plugin-run-script-2.1.7.tgz#30f50cc76251f9c857ccaa6b725bfa509765d9dd"
+  integrity sha512-+gwR03tsXDJf3OU0LJ40nZVZXVUu2nr8V5C3rLOHjlJ3U1vYY0WCcS9IvhrO3eYakOg5Git8JDZIakJ1wczvBA==
   dependencies:
     execa "^4.0.3"
     npm-run-path "^4.0.1"
@@ -3513,10 +3513,10 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-esinstall@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/esinstall/-/esinstall-0.3.3.tgz#d43b4f62a6d5090fa2eaadea425c09a985c6c05f"
-  integrity sha512-FkC0fGn7GJPxWS58YvAdXkALCv2WFV6xnWHMVYXIupO0QvRUkaKx6bRCb6Kq+KuaFvmgTgFGp4zzAWljgD9tuQ==
+esinstall@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/esinstall/-/esinstall-0.3.4.tgz#3040e23af29a6b0c5eff8533e4fbb933d4a31532"
+  integrity sha512-UKlx03ARe6NiZ8IVsWZA4vZiSWBBG/JK7sH7+MiI3uXobY8eMd6tU7j5xjUaQoJ7wpaBq449Zm3Z6LL2BbyV7w==
   dependencies:
     "@rollup/plugin-alias" "^3.0.1"
     "@rollup/plugin-commonjs" "^15.0.0"
@@ -6978,13 +6978,13 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-snowpack@next:
-  version "2.15.0-pre.6"
-  resolved "https://registry.yarnpkg.com/snowpack/-/snowpack-2.15.0-pre.6.tgz#d13d19448ddcd3fa5636fb5d5bc3bbdb98220dbd"
-  integrity sha512-wD74EXTZ8+OciZ/VrabUBw8iWHhWCv6ahW9na0M2fcvo2P1z4BRiHcYF0EtIYUKaX8nNBEvBO7SEBZyqJ2CaFg==
+snowpack@^2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/snowpack/-/snowpack-2.15.0.tgz#3937aecb12c657df629c410ea0767916affe5ca5"
+  integrity sha512-2T9pqIYc/1RXWQzrkLqyJx9QtQnI1UfkKfJfrnn8qd6u0446Jw6l5+47VcEUQqRoH4TasVsra8tJO4Zw2BKZrg==
   dependencies:
-    "@snowpack/plugin-build-script" "^2.0.10"
-    "@snowpack/plugin-run-script" "^2.1.6"
+    "@snowpack/plugin-build-script" "^2.0.11"
+    "@snowpack/plugin-run-script" "^2.1.7"
     cacache "^15.0.0"
     cachedir "^2.3.0"
     chokidar "^3.4.0"
@@ -6995,7 +6995,7 @@ snowpack@next:
     detect-port "^1.3.0"
     es-module-lexer "^0.3.24"
     esbuild "^0.7.0"
-    esinstall "^0.3.3"
+    esinstall "^0.3.4"
     etag "^1.8.1"
     execa "^4.0.3"
     find-cache-dir "^3.3.1"


### PR DESCRIPTION
- Update to latest, optimized version of Snowpack
- Update to latest recommended Snowpack config

Follow up work that I'd recommend:

- Can we create some file nesting to better imitate a real-world app? Maybe 10 files, loading 10 files, loading 10 files each?
- Add a "warm server ready" column (vs. "cold server ready"). webpack does some caching as well so I'm sure they'd like to see that benchmark.
- more fine-grained on the inner-loop & HMR times (50ms and 600ms are very different)
- Why couldn't webpack handle HMR? That's an essential measure of perf for us, would love a reason why if it wasn't possible.
- Update the benchmark itself (assumed this was run on your machine)
  